### PR TITLE
[#42] Feat: GET daily-dust-status Mock API 구현

### DIFF
--- a/BE/README.md
+++ b/BE/README.md
@@ -19,14 +19,138 @@
 ]
 ```
 
-`GET` 요청으로 `/강남구/dust-status`를 호출하면 아래와 같은 데이터를 반환합니다. (Mock)
+`GET` 요청으로 `/강남구/daily-dust-status`를 호출하면 아래와 같은 데이터를 반환합니다. (Mock)  
+pm10Grade1h, pm10Value: 가 "-1"을 반환하는 경우 데이터가 조회되지 않았다는 의미입니다.  
+pm10Grade1h: 1: 좋음, 2: 보통, 3: 나쁨, 4: 매우나쁨
 
 ```json
-{
-    "pm10Grade1h": 2,
-    "pm10Value": 74,
-    "location": "강남구"
-}
+[
+    {
+        "pm10Grade1h": "4",
+        "pm10Value": "205",
+        "dateTime": "2020-03-31 12:00"
+    },
+    {
+        "pm10Grade1h": "4",
+        "pm10Value": "180",
+        "dateTime": "2020-03-31 11:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "55",
+        "dateTime": "2020-03-31 10:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "51",
+        "dateTime": "2020-03-31 09:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "42",
+        "dateTime": "2020-03-31 08:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "41",
+        "dateTime": "2020-03-31 07:00"
+    },
+    {
+        "pm10Grade1h": "1",
+        "pm10Value": "0",
+        "dateTime": "2020-03-31 06:00"
+    },
+    {
+        "pm10Grade1h": "1",
+        "pm10Value": "30",
+        "dateTime": "2020-03-31 05:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "36",
+        "dateTime": "2020-03-31 04:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "38",
+        "dateTime": "2020-03-31 03:00"
+    },
+    {
+        "pm10Grade1h": "3",
+        "pm10Value": "99",
+        "dateTime": "2020-03-31 02:00"
+    },
+    {
+        "pm10Grade1h": "3",
+        "pm10Value": "150",
+        "dateTime": "2020-03-31 01:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "35",
+        "dateTime": "2020-03-30 24:00"
+    },
+    {
+        "pm10Grade1h": "3",
+        "pm10Value": "81",
+        "dateTime": "2020-03-30 23:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "39",
+        "dateTime": "2020-03-30 22:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "42",
+        "dateTime": "2020-03-30 21:00"
+    },
+    {
+        "pm10Grade1h": "4",
+        "pm10Value": "151",
+        "dateTime": "2020-03-30 20:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "54",
+        "dateTime": "2020-03-30 19:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "80",
+        "dateTime": "2020-03-30 18:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "52",
+        "dateTime": "2020-03-30 17:00"
+    },
+    {
+        "pm10Grade1h": "",
+        "pm10Value": "-",
+        "dateTime": "2020-03-30 16:00"
+    },
+    {
+        "pm10Grade1h": "",
+        "pm10Value": "-",
+        "dateTime": "2020-03-30 15:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "49",
+        "dateTime": "2020-03-30 14:00"
+    },
+    {
+        "pm10Grade1h": "1",
+        "pm10Value": "15",
+        "dateTime": "2020-03-30 13:00"
+    },
+    {
+        "pm10Grade1h": "2",
+        "pm10Value": "51",
+        "dateTime": "2020-03-30 12:00"
+    }
+]
 ```
 
 `GET` 요청으로 `/location/@=37.49085787273425,127.03369659888592` 를 호출하면 아래와 같은 데이터를 반환합니다. (Mock)

--- a/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
@@ -30,13 +30,41 @@ public class FineDustApiController {
         return stationLocations;
     }
 
-    @GetMapping("/{stationName}/dust-status")
-    public DustStatus showDustStatus(@PathVariable String stationName) {
-        DustStatus dustStatus = new DustStatus(2, 74, stationName);
+    @GetMapping("/{stationName}/daily-dust-status")
+    public List<DustStatus> showDailyDustStatus(@PathVariable String stationName) {
+        List<DustStatus> dustStatusList = new ArrayList<>();
 
-        log.debug("dustStatus: {}", dustStatus);
+        log.debug("stationName: {}", stationName);
 
-        return dustStatus;
+        dustStatusList.add(new DustStatus("4", "205", "2020-03-31 12:00"));
+        dustStatusList.add(new DustStatus("4", "180", "2020-03-31 11:00"));
+        dustStatusList.add(new DustStatus("2", "55", "2020-03-31 10:00"));
+        dustStatusList.add(new DustStatus("2", "51", "2020-03-31 09:00"));
+        dustStatusList.add(new DustStatus("2", "42", "2020-03-31 08:00"));
+        dustStatusList.add(new DustStatus("2", "41", "2020-03-31 07:00"));
+        dustStatusList.add(new DustStatus("1", "0", "2020-03-31 06:00"));
+        dustStatusList.add(new DustStatus("1", "30", "2020-03-31 05:00"));
+        dustStatusList.add(new DustStatus("2", "36", "2020-03-31 04:00"));
+        dustStatusList.add(new DustStatus("2", "38", "2020-03-31 03:00"));
+        dustStatusList.add(new DustStatus("3", "99", "2020-03-31 02:00"));
+        dustStatusList.add(new DustStatus("3", "150", "2020-03-31 01:00"));
+        dustStatusList.add(new DustStatus("2", "35", "2020-03-30 24:00"));
+        dustStatusList.add(new DustStatus("3", "81", "2020-03-30 23:00"));
+        dustStatusList.add(new DustStatus("2", "39", "2020-03-30 22:00"));
+        dustStatusList.add(new DustStatus("2", "42", "2020-03-30 21:00"));
+        dustStatusList.add(new DustStatus("4", "151", "2020-03-30 20:00"));
+        dustStatusList.add(new DustStatus("2", "54", "2020-03-30 19:00"));
+        dustStatusList.add(new DustStatus("2", "80", "2020-03-30 18:00"));
+        dustStatusList.add(new DustStatus("2", "52", "2020-03-30 17:00"));
+        dustStatusList.add(new DustStatus("-1", "-1", "2020-03-30 16:00"));
+        dustStatusList.add(new DustStatus("-1", "-1", "2020-03-30 15:00"));
+        dustStatusList.add(new DustStatus("2", "49", "2020-03-30 14:00"));
+        dustStatusList.add(new DustStatus("1", "15", "2020-03-30 13:00"));
+        dustStatusList.add(new DustStatus("2", "51", "2020-03-30 12:00"));
+
+        log.debug("dustStatusList: {}", dustStatusList);
+
+        return dustStatusList;
     }
 
     @GetMapping("/location/@={latitude},{longitude}")

--- a/BE/src/main/java/com/codesquad/team1/dust/domain/DustStatus.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/domain/DustStatus.java
@@ -2,42 +2,42 @@ package com.codesquad.team1.dust.domain;
 
 public class DustStatus {
 
-    private int pm10Grade1h;
-    private int pm10Value;
-    private String location;
+    private String pm10Grade1h;
+    private String pm10Value;
+    private String dateTime;
 
-    public DustStatus(int pm10Grade1h, int pm10Value, String location) {
+    public DustStatus(String pm10Grade1h, String pm10Value, String dateTime) {
         this.pm10Grade1h = pm10Grade1h;
         this.pm10Value = pm10Value;
-        this.location = location;
+        this.dateTime = dateTime;
     }
 
-    public int getPm10Grade1h() {
+    public String getPm10Grade1h() {
         return pm10Grade1h;
     }
 
-    public void setPm10Grade1h(int pm10Grade1h) {
+    public void setPm10Grade1h(String pm10Grade1h) {
         this.pm10Grade1h = pm10Grade1h;
     }
 
-    public int getPm10Value() {
+    public String getPm10Value() {
         return pm10Value;
     }
 
-    public void setPm10Value(int pm10Value) {
+    public void setPm10Value(String pm10Value) {
         this.pm10Value = pm10Value;
     }
 
-    public String getLocation() {
-        return location;
+    public String getDateTime() {
+        return dateTime;
     }
 
-    public void setLocation(String location) {
-        this.location = location;
+    public void setDateTime(String dateTime) {
+        this.dateTime = dateTime;
     }
 
     @Override
     public String toString() {
-        return "DustStatus{" + "pm10Grade1h=" + pm10Grade1h + ", pm10Value=" + pm10Value + ", location='" + location + '\'' + '}';
+        return "DustStatus{" + "pm10Grade1h=" + pm10Grade1h + ", pm10Value=" + pm10Value + ", dateTime='" + dateTime + '\'' + '}';
     }
 }


### PR DESCRIPTION
 - 측정 장소의 최근 24시간 미세먼지 추이를 반환합니다.
 - dust-status 가 필요 없어져서 제거하였습니다.
 - 간혹가다 데이터가 존재하지 않는 경우가 있어서 DataType을 int에서 String으로 변환하고, 데이터가 존재하지 않는 경우 -1을 반환하도록 하였습니다.
 - DustStatus에 측정 시간 정보도 포함하도록 하였습니다.
 - 리스트는 시간의 역순으로 배치하여 반환합니다.
 - Close #42 Issue.