### PR TITLE
[#49] Feat: API Docs Swagger 설정

### DIFF
--- a/BE/README.md
+++ b/BE/README.md
@@ -4,6 +4,8 @@
 
 ## API Manual
 
+접속주소/swagger-ui.html의 fine-dust-api-controller를 이용하면 테스트도 가능합니다.
+
 `GET` 요청으로 `/locations` 를 호출하면 아래와 같은 데이터를 반환합니다. (Mock)
 
 ```json

--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -21,6 +21,9 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.springfox:springfox-swagger2:2.9.2'
+    implementation'io.springfox:springfox-swagger-ui:2.9.2'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/BE/src/main/java/com/codesquad/team1/dust/config/SpringFoxConfig.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/config/SpringFoxConfig.java
@@ -1,0 +1,23 @@
+package com.codesquad.team1.dust.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SpringFoxConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+    }
+}


### PR DESCRIPTION
 - API Docs를 Swagger를 이용해서 제공합니다.
 - 보시기 편하게 Swagger UI도 적용하였습니다. (접속주소: swagger-ui.html)
 - Close #49 Issue.
