### PR TITLE
[#62, #67] daily-dust-status API 구현

### DIFF
--- a/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
@@ -3,21 +3,17 @@ package com.codesquad.team1.dust.api;
 import com.codesquad.team1.dust.domain.DustStatus;
 import com.codesquad.team1.dust.domain.Forecast;
 import com.codesquad.team1.dust.domain.StationLocation;
-import org.json.JSONObject;
+import com.codesquad.team1.dust.util.PublicAPIUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.codesquad.team1.dust.constants.CommonConstants.*;
 
 @RestController
 public class FineDustApiController {
@@ -84,23 +80,10 @@ public class FineDustApiController {
         return stationLocation;
     }
 
-    // 날짜는 Default로 금일
     @GetMapping("/forecast")
     public Forecast showForecastOfFineDust() throws URISyntaxException {
         String today = LocalDate.now().toString();
-        URI publicApiRequestUrl = new URI(PUBLIC_API_FORECAST_URL_AND_SEARCH_DATE + today
-                + AND_SERVICE_KEY + PUBLIC_API_SERVICE_KEY + RETURN_TYPE_JSON);
-
-        RestTemplate restTemplate = new RestTemplate();
-        String response = restTemplate.getForObject(publicApiRequestUrl, String.class);
-        JSONObject forecastObject = new JSONObject(response).getJSONArray("list").getJSONObject(0);
-
-        log.debug("오늘 날짜: {}", today);
-        log.debug("requestUrl: {}", publicApiRequestUrl);
-        log.debug("response: {}", response);
-        log.debug("forecastJSONObject: {}", forecastObject);
-
-        Forecast forecast = new Forecast(forecastObject);
+        Forecast forecast = new Forecast(PublicAPIUtils.getForecastJSONObject(today));
 
         log.debug("forecast: {}", forecast);
 

--- a/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
@@ -33,37 +33,10 @@ public class FineDustApiController {
     }
 
     @GetMapping("/{stationName}/daily-dust-status")
-    public List<DustStatus> showDailyDustStatus(@PathVariable String stationName) {
-        List<DustStatus> dustStatusList = new ArrayList<>();
+    public List<DustStatus> showDailyDustStatus(@PathVariable String stationName) throws URISyntaxException {
+        List<DustStatus> dustStatusList = PublicAPIUtils.getDailyDustStatusJSONArray(stationName);
 
         log.debug("stationName: {}", stationName);
-
-        dustStatusList.add(new DustStatus("4", "205", "2020-03-31 12:00"));
-        dustStatusList.add(new DustStatus("4", "180", "2020-03-31 11:00"));
-        dustStatusList.add(new DustStatus("2", "55", "2020-03-31 10:00"));
-        dustStatusList.add(new DustStatus("2", "51", "2020-03-31 09:00"));
-        dustStatusList.add(new DustStatus("2", "42", "2020-03-31 08:00"));
-        dustStatusList.add(new DustStatus("2", "41", "2020-03-31 07:00"));
-        dustStatusList.add(new DustStatus("1", "0", "2020-03-31 06:00"));
-        dustStatusList.add(new DustStatus("1", "30", "2020-03-31 05:00"));
-        dustStatusList.add(new DustStatus("2", "36", "2020-03-31 04:00"));
-        dustStatusList.add(new DustStatus("2", "38", "2020-03-31 03:00"));
-        dustStatusList.add(new DustStatus("3", "99", "2020-03-31 02:00"));
-        dustStatusList.add(new DustStatus("3", "150", "2020-03-31 01:00"));
-        dustStatusList.add(new DustStatus("2", "35", "2020-03-30 24:00"));
-        dustStatusList.add(new DustStatus("3", "81", "2020-03-30 23:00"));
-        dustStatusList.add(new DustStatus("2", "39", "2020-03-30 22:00"));
-        dustStatusList.add(new DustStatus("2", "42", "2020-03-30 21:00"));
-        dustStatusList.add(new DustStatus("4", "151", "2020-03-30 20:00"));
-        dustStatusList.add(new DustStatus("2", "54", "2020-03-30 19:00"));
-        dustStatusList.add(new DustStatus("2", "80", "2020-03-30 18:00"));
-        dustStatusList.add(new DustStatus("2", "52", "2020-03-30 17:00"));
-        dustStatusList.add(new DustStatus("-1", "-1", "2020-03-30 16:00"));
-        dustStatusList.add(new DustStatus("-1", "-1", "2020-03-30 15:00"));
-        dustStatusList.add(new DustStatus("2", "49", "2020-03-30 14:00"));
-        dustStatusList.add(new DustStatus("1", "15", "2020-03-30 13:00"));
-        dustStatusList.add(new DustStatus("2", "51", "2020-03-30 12:00"));
-
         log.debug("dustStatusList: {}", dustStatusList);
 
         return dustStatusList;

--- a/BE/src/main/java/com/codesquad/team1/dust/constants/CommonConstants.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/constants/CommonConstants.java
@@ -5,7 +5,12 @@ public class CommonConstants {
     public static final String PUBLIC_API_SERVICE_KEY = "qh1W9WhS1Wl%2BH90EXv4PO2hR1k11hXsBngVTfuehLCm%2BxDFqBzITeVMij4tmxljJSyA%2FstR9HRpfidM6Vi%2BG3Q%3D%3D";
     public static final String PUBLIC_API_FORECAST_URL_AND_SEARCH_DATE =
             "http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMinuDustFrcstDspth?searchDate=";
+    public static final String PUBLIC_API_REALTIME_MEASURE_URL = "http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMsrstnAcctoRltmMesureDnsty?stationName=";
+    public static final String AND_DATA_TERM_DAILY = "&dataTerm=daily";
+    public static final String AND_PAGE_NO_1 = "&pageNo=1";
+    public static final String AND_NUM_OF_ROWS_24 = "&numOfRows=24";
     public static final String AND_SERVICE_KEY = "&ServiceKey=";
+    public static final String AND_VERSION = "&ver=";
     public static final String AND_RETURN_TYPE_JSON = "&_returnType=json";
 
     private CommonConstants() {}

--- a/BE/src/main/java/com/codesquad/team1/dust/constants/CommonConstants.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/constants/CommonConstants.java
@@ -6,7 +6,7 @@ public class CommonConstants {
     public static final String PUBLIC_API_FORECAST_URL_AND_SEARCH_DATE =
             "http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMinuDustFrcstDspth?searchDate=";
     public static final String AND_SERVICE_KEY = "&ServiceKey=";
-    public static final String RETURN_TYPE_JSON = "&_returnType=json";
+    public static final String AND_RETURN_TYPE_JSON = "&_returnType=json";
 
     private CommonConstants() {}
 }

--- a/BE/src/main/java/com/codesquad/team1/dust/domain/DustStatus.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/domain/DustStatus.java
@@ -1,15 +1,19 @@
 package com.codesquad.team1.dust.domain;
 
+import org.json.JSONObject;
+
 public class DustStatus {
 
     private String pm10Grade1h;
     private String pm10Value;
     private String dateTime;
 
-    public DustStatus(String pm10Grade1h, String pm10Value, String dateTime) {
-        this.pm10Grade1h = pm10Grade1h;
-        this.pm10Value = pm10Value;
-        this.dateTime = dateTime;
+    public DustStatus(JSONObject dustStatusJSONObject) {
+        String pm10Grade1hJSON = dustStatusJSONObject.getString("pm10Grade1h");
+        String pm10ValueJSON = dustStatusJSONObject.getString("pm10Value");
+        this.pm10Grade1h = pm10Grade1hJSON.equals("") ? "-1" : pm10Grade1hJSON;
+        this.pm10Value = pm10ValueJSON.equals("-") ? "-1" : pm10ValueJSON;
+        this.dateTime = dustStatusJSONObject.getString("dataTime");
     }
 
     public String getPm10Grade1h() {

--- a/BE/src/main/java/com/codesquad/team1/dust/domain/DustStatus.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/domain/DustStatus.java
@@ -9,11 +9,19 @@ public class DustStatus {
     private String dateTime;
 
     public DustStatus(JSONObject dustStatusJSONObject) {
-        String pm10Grade1hJSON = dustStatusJSONObject.getString("pm10Grade1h");
-        String pm10ValueJSON = dustStatusJSONObject.getString("pm10Value");
-        this.pm10Grade1h = pm10Grade1hJSON.equals("") ? "-1" : pm10Grade1hJSON;
-        this.pm10Value = pm10ValueJSON.equals("-") ? "-1" : pm10ValueJSON;
+        this.pm10Grade1h = getPm10Grade1hFrom(dustStatusJSONObject);
+        this.pm10Value = getPm10ValueFrom(dustStatusJSONObject);
         this.dateTime = dustStatusJSONObject.getString("dataTime");
+    }
+
+    private String getPm10ValueFrom(JSONObject dustStatusJSONObject) {
+        String pm10ValueJSON = dustStatusJSONObject.getString("pm10Value");
+        return pm10ValueJSON.equals("-") ? "-1" : pm10ValueJSON;
+    }
+
+    private String getPm10Grade1hFrom(JSONObject dustStatusJSONObject) {
+        String pm10Grade1hJSON = dustStatusJSONObject.getString("pm10Grade1h");
+        return pm10Grade1hJSON.equals("") ? "-1" : pm10Grade1hJSON;
     }
 
     public String getPm10Grade1h() {

--- a/BE/src/main/java/com/codesquad/team1/dust/util/PublicAPIUtils.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/util/PublicAPIUtils.java
@@ -1,5 +1,7 @@
 package com.codesquad.team1.dust.util;
 
+import com.codesquad.team1.dust.domain.DustStatus;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,30 +9,51 @@ import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
-import static com.codesquad.team1.dust.constants.CommonConstants.AND_RETURN_TYPE_JSON;
-import static com.codesquad.team1.dust.constants.CommonConstants.AND_SERVICE_KEY;
-import static com.codesquad.team1.dust.constants.CommonConstants.PUBLIC_API_FORECAST_URL_AND_SEARCH_DATE;
-import static com.codesquad.team1.dust.constants.CommonConstants.PUBLIC_API_SERVICE_KEY;
+import static com.codesquad.team1.dust.constants.CommonConstants.*;
 
 public class PublicAPIUtils {
 
     private static final Logger log = LoggerFactory.getLogger(PublicAPIUtils.class);
+    private static final RestTemplate restTemplate = new RestTemplate();
 
     public static JSONObject getForecastJSONObject(String searchDate) throws URISyntaxException {
+        log.debug("검색한 날짜: {}", searchDate);
         URI publicApiRequestUrl = new URI(PUBLIC_API_FORECAST_URL_AND_SEARCH_DATE + searchDate
                 + AND_SERVICE_KEY + PUBLIC_API_SERVICE_KEY + AND_RETURN_TYPE_JSON);
-
-        RestTemplate restTemplate = new RestTemplate();
-        String response = restTemplate.getForObject(publicApiRequestUrl, String.class);
-        JSONObject forecastObject = new JSONObject(response).getJSONArray("list").getJSONObject(0);
-
-        log.debug("검색한 날짜: {}", searchDate);
         log.debug("requestUrl: {}", publicApiRequestUrl);
+
+        String response = restTemplate.getForObject(publicApiRequestUrl, String.class);
         log.debug("response: {}", response);
+        JSONObject forecastObject = new JSONObject(response).getJSONArray("list").getJSONObject(0);
         log.debug("forecastJSONObject: {}", forecastObject);
 
         return forecastObject;
     }
 
+    public static List<DustStatus> getDailyDustStatusJSONArray(String stationName) throws URISyntaxException {
+        List<DustStatus> dustStatusList = new ArrayList<>();
+        URI publicApiRequestUrl = new URI(PUBLIC_API_REALTIME_MEASURE_URL + stationName
+                + AND_DATA_TERM_DAILY + AND_PAGE_NO_1 + AND_NUM_OF_ROWS_24 + AND_SERVICE_KEY + PUBLIC_API_SERVICE_KEY
+                + AND_VERSION + 1.3 + AND_RETURN_TYPE_JSON);
+        log.debug("requestUrl: {}", publicApiRequestUrl);
+
+        String response = restTemplate.getForObject(publicApiRequestUrl, String.class);
+        log.debug("response: {}", response);
+
+        JSONArray dustStatuses = new JSONObject(response).getJSONArray("list");
+        log.debug("dustStatuses: {}", dustStatuses);
+
+        for (Object dustStatusObject : dustStatuses) {
+            JSONObject dustStatusJSONObject = (JSONObject) dustStatusObject;
+            dustStatusList.add(new DustStatus(dustStatusJSONObject));
+        }
+        log.debug("dustStatusList: {}", dustStatusList);
+
+        return dustStatusList;
+    }
+
+    private PublicAPIUtils() {}
 }

--- a/BE/src/main/java/com/codesquad/team1/dust/util/PublicAPIUtils.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/util/PublicAPIUtils.java
@@ -1,0 +1,36 @@
+package com.codesquad.team1.dust.util;
+
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static com.codesquad.team1.dust.constants.CommonConstants.AND_RETURN_TYPE_JSON;
+import static com.codesquad.team1.dust.constants.CommonConstants.AND_SERVICE_KEY;
+import static com.codesquad.team1.dust.constants.CommonConstants.PUBLIC_API_FORECAST_URL_AND_SEARCH_DATE;
+import static com.codesquad.team1.dust.constants.CommonConstants.PUBLIC_API_SERVICE_KEY;
+
+public class PublicAPIUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(PublicAPIUtils.class);
+
+    public static JSONObject getForecastJSONObject(String searchDate) throws URISyntaxException {
+        URI publicApiRequestUrl = new URI(PUBLIC_API_FORECAST_URL_AND_SEARCH_DATE + searchDate
+                + AND_SERVICE_KEY + PUBLIC_API_SERVICE_KEY + AND_RETURN_TYPE_JSON);
+
+        RestTemplate restTemplate = new RestTemplate();
+        String response = restTemplate.getForObject(publicApiRequestUrl, String.class);
+        JSONObject forecastObject = new JSONObject(response).getJSONArray("list").getJSONObject(0);
+
+        log.debug("검색한 날짜: {}", searchDate);
+        log.debug("requestUrl: {}", publicApiRequestUrl);
+        log.debug("response: {}", response);
+        log.debug("forecastJSONObject: {}", forecastObject);
+
+        return forecastObject;
+    }
+
+}


### PR DESCRIPTION
- API를 작성하는 과정에서 중복된 코드가 발생할 것 같아 리팩토링을 겸합니다.
- 기존 daily-dust-status 와 반환하는 데이터 형식은 동일합니다.
- 로깅을 하도록 구현하였습니다.
- Close #62 Issue.
- Close #67 Issue.