### PR TITLE
[#82] gif를 여러 장의 이미지로 변환하여 전송

### DIFF
--- a/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
@@ -2,6 +2,7 @@ package com.codesquad.team1.dust.api;
 
 import com.codesquad.team1.dust.domain.DustStatus;
 import com.codesquad.team1.dust.domain.Forecast;
+import com.codesquad.team1.dust.domain.Image;
 import com.codesquad.team1.dust.domain.StationLocation;
 import com.codesquad.team1.dust.util.ResourceUtils;
 import com.codesquad.team1.dust.util.KakaoAPIUtils;
@@ -61,8 +62,8 @@ public class FineDustApiController {
     public Forecast showForecastOfFineDust() throws URISyntaxException, JsonProcessingException {
         String today = LocalDate.now().toString();
         JsonNode forecastObject = PublicAPIUtils.getForecastJSONObject(today);
-        List<String> imageURLs= ResourceUtils.getImageURLs();
-        Forecast forecast = new Forecast(forecastObject, imageURLs);
+        List<Image> images = ResourceUtils.getImages();
+        Forecast forecast = new Forecast(forecastObject, images);
 
         log.debug("forecast: {}", forecast);
 

--- a/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
@@ -3,7 +3,7 @@ package com.codesquad.team1.dust.api;
 import com.codesquad.team1.dust.domain.DustStatus;
 import com.codesquad.team1.dust.domain.Forecast;
 import com.codesquad.team1.dust.domain.StationLocation;
-import com.codesquad.team1.dust.util.ImageResourceUtils;
+import com.codesquad.team1.dust.util.ResourceUtils;
 import com.codesquad.team1.dust.util.KakaoAPIUtils;
 import com.codesquad.team1.dust.util.PublicAPIUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -61,7 +61,7 @@ public class FineDustApiController {
     public Forecast showForecastOfFineDust() throws URISyntaxException, JsonProcessingException {
         String today = LocalDate.now().toString();
         JsonNode forecastObject = PublicAPIUtils.getForecastJSONObject(today);
-        List<String> imageURLs= ImageResourceUtils.parseImageURLs(forecastObject);
+        List<String> imageURLs= ResourceUtils.getImageURLs();
         Forecast forecast = new Forecast(forecastObject, imageURLs);
 
         log.debug("forecast: {}", forecast);

--- a/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
@@ -3,9 +3,11 @@ package com.codesquad.team1.dust.api;
 import com.codesquad.team1.dust.domain.DustStatus;
 import com.codesquad.team1.dust.domain.Forecast;
 import com.codesquad.team1.dust.domain.StationLocation;
+import com.codesquad.team1.dust.util.ImageResourceUtils;
 import com.codesquad.team1.dust.util.KakaoAPIUtils;
 import com.codesquad.team1.dust.util.PublicAPIUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -58,7 +60,9 @@ public class FineDustApiController {
     @GetMapping("/forecast")
     public Forecast showForecastOfFineDust() throws URISyntaxException, JsonProcessingException {
         String today = LocalDate.now().toString();
-        Forecast forecast = new Forecast(PublicAPIUtils.getForecastJSONObject(today));
+        JsonNode forecastObject = PublicAPIUtils.getForecastJSONObject(today);
+        List<String> imageURLs= ImageResourceUtils.parseImageURLs(forecastObject);
+        Forecast forecast = new Forecast(forecastObject, imageURLs);
 
         log.debug("forecast: {}", forecast);
 

--- a/BE/src/main/java/com/codesquad/team1/dust/domain/Forecast.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/domain/Forecast.java
@@ -12,10 +12,10 @@ public class Forecast {
     private String informGrade;
     private List<Image> images;
 
-    public Forecast(JsonNode forecastObject) {
+    public Forecast(JsonNode forecastObject, List<String> imageURLs) {
         this.informOverall = forecastObject.get("informOverall").asText();
         this.informGrade = forecastObject.get("informGrade").asText();
-        this.images = parseImages(forecastObject);
+        this.images = parseImages(imageURLs);
     }
 
     public Forecast(String informOverall, String informGrade, List<Image> images) {
@@ -27,9 +27,8 @@ public class Forecast {
     private List<Image> parseImages(JsonNode forecastObject) {
         List<Image> images = new ArrayList<>();
 
-        images.add(new Image(forecastObject.get("imageUrl1").asText()));
-        images.add(new Image(forecastObject.get("imageUrl2").asText()));
-        images.add(new Image(forecastObject.get("imageUrl3").asText()));
+        for (String imageURL : imageURLs)
+            images.add(new Image(imageURL));
 
         return images;
     }

--- a/BE/src/main/java/com/codesquad/team1/dust/domain/Forecast.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/domain/Forecast.java
@@ -24,7 +24,7 @@ public class Forecast {
         this.images = images;
     }
 
-    private List<Image> parseImages(JsonNode forecastObject) {
+    private List<Image> parseImages(List<String> imageURLs) {
         List<Image> images = new ArrayList<>();
 
         for (String imageURL : imageURLs)

--- a/BE/src/main/java/com/codesquad/team1/dust/domain/Forecast.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/domain/Forecast.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 public class Forecast {
 

--- a/BE/src/main/java/com/codesquad/team1/dust/domain/Forecast.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/domain/Forecast.java
@@ -2,7 +2,6 @@ package com.codesquad.team1.dust.domain;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class Forecast {
@@ -11,25 +10,16 @@ public class Forecast {
     private String informGrade;
     private List<Image> images;
 
-    public Forecast(JsonNode forecastObject, List<String> imageURLs) {
+    public Forecast(JsonNode forecastObject, List<Image> images) {
         this.informOverall = forecastObject.get("informOverall").asText();
         this.informGrade = forecastObject.get("informGrade").asText();
-        this.images = parseImages(imageURLs);
+        this.images = images;
     }
 
     public Forecast(String informOverall, String informGrade, List<Image> images) {
         this.informOverall = informOverall;
         this.informGrade = informGrade;
         this.images = images;
-    }
-
-    private List<Image> parseImages(List<String> imageURLs) {
-        List<Image> images = new ArrayList<>();
-
-        for (String imageURL : imageURLs)
-            images.add(new Image(imageURL));
-
-        return images;
     }
 
     public String getInformOverall() {

--- a/BE/src/main/java/com/codesquad/team1/dust/runner/DustApplicationRunner.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/runner/DustApplicationRunner.java
@@ -1,0 +1,20 @@
+package com.codesquad.team1.dust.runner;
+
+import com.codesquad.team1.dust.util.ResourceUtils;
+import com.codesquad.team1.dust.util.PublicAPIUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class DustApplicationRunner implements ApplicationRunner {
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        String today = LocalDate.now().toString();
+        JsonNode forecastObject = PublicAPIUtils.getForecastJSONObject(today);
+        ResourceUtils.convertGIFtoPNGs(forecastObject);
+    }
+}

--- a/BE/src/main/java/com/codesquad/team1/dust/runner/DustApplicationRunner.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/runner/DustApplicationRunner.java
@@ -2,7 +2,6 @@ package com.codesquad.team1.dust.runner;
 
 import com.codesquad.team1.dust.util.ResourceUtils;
 import com.codesquad.team1.dust.util.PublicAPIUtils;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
@@ -11,10 +10,10 @@ import java.time.LocalDate;
 
 @Component
 public class DustApplicationRunner implements ApplicationRunner {
+
     @Override
     public void run(ApplicationArguments args) throws Exception {
         String today = LocalDate.now().toString();
-        JsonNode forecastObject = PublicAPIUtils.getForecastJSONObject(today);
-        ResourceUtils.convertGIFtoPNGs(forecastObject);
+        ResourceUtils.convertGIFtoPNGs(PublicAPIUtils.getForecastJSONObject(today));
     }
 }

--- a/BE/src/main/java/com/codesquad/team1/dust/util/ImageResourceUtils.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/util/ImageResourceUtils.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,12 +12,14 @@ public class ImageResourceUtils {
 
     private static final Logger log = LoggerFactory.getLogger(ImageResourceUtils.class);
     private static final String DIR_IMAGES_PATH = System.getProperty("user.dir") + "/src/main/resources/static/images";
-    private static final String IMAGE_URI = "ec2-15-164-254-158.ap-northeast-2.compute.amazonaws.com:8080/images/";
+    private static final String IMAGE_URI = "http://ec2-15-164-254-158.ap-northeast-2.compute.amazonaws.com:8080/images/";
+    private static final String IMAGE_PREFIX = "forecast";
+    private static final int MAX_IMAGES = 48;
 
     public static List<String> parseImageURLs(JsonNode forecastObject) {
         log.debug("pm10 gif imageUrl7 : {}", forecastObject.get("imageUrl7"));
         log.debug("resource path : {}", DIR_IMAGES_PATH);
-        excuteGIFSplit(String.format("convert %s %s/forecast.png", forecastObject.get("imageUrl7"), DIR_IMAGES_PATH));
+        excuteGIFSplit(String.format("convert %s %s/%s.png", forecastObject.get("imageUrl7"), DIR_IMAGES_PATH, IMAGE_PREFIX));
         return getImageURLs();
     }
 
@@ -55,15 +56,8 @@ public class ImageResourceUtils {
 
     private static List<String> getImageURLs() {
         List<String> imageURLs = new ArrayList<>();
-        File[] imageFiles = new File(DIR_IMAGES_PATH).listFiles();
-
-        for (File imageFile : imageFiles) {
-            if (imageFile.isFile()) {
-                String imageURL = IMAGE_URI + imageFile.getName();
-                log.debug("imageURL : {}", imageURL);
-                imageURLs.add(imageURL);
-            }
-        }
+        for (int i = 0; i < MAX_IMAGES; ++i)
+            imageURLs.add(String.format("%s%s-%d.png", IMAGE_URI, IMAGE_PREFIX, i));
         return imageURLs;
     }
 

--- a/BE/src/main/java/com/codesquad/team1/dust/util/ImageResourceUtils.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/util/ImageResourceUtils.java
@@ -1,0 +1,4 @@
+package com.codesquad.team1.dust.util;
+
+public class ImageResourceUtils {
+}

--- a/BE/src/main/java/com/codesquad/team1/dust/util/ImageResourceUtils.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/util/ImageResourceUtils.java
@@ -1,4 +1,71 @@
 package com.codesquad.team1.dust.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 public class ImageResourceUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(ImageResourceUtils.class);
+    private static final String DIR_IMAGES_PATH = System.getProperty("user.dir") + "/src/main/resources/static/images";
+    private static final String IMAGE_URI = "ec2-15-164-254-158.ap-northeast-2.compute.amazonaws.com:8080/images/";
+
+    public static List<String> parseImageURLs(JsonNode forecastObject) {
+        log.debug("pm10 gif imageUrl7 : {}", forecastObject.get("imageUrl7"));
+        log.debug("resource path : {}", DIR_IMAGES_PATH);
+        excuteGIFSplit(String.format("convert %s %s/forecast.png", forecastObject.get("imageUrl7"), DIR_IMAGES_PATH));
+        return getImageURLs();
+    }
+
+    private static void excuteGIFSplit(String command) {
+        Runtime runtime = Runtime.getRuntime();
+        Process process = null;
+        try {
+            // 명령어 실행
+            process = runtime.exec(readyCommandLists(command));
+            // 프로세스의 수행이 끝날때까지 대기
+            process.waitFor();
+            // shell 실행이 정상 종료되었을 경우
+            if (process.exitValue() != 0) {
+                log.info("linux Command Run Fail");
+                return;
+            }
+            log.info("linux Command Run Success");
+        } catch (IOException | InterruptedException e) {
+            log.debug("excuteGIFSplit() exception : {}", e.getMessage());
+        } finally {
+            if (process != null)
+                process.destroy();
+        }
+    }
+
+    private static String[] readyCommandLists(String command) {
+        // 명령어 셋팅
+        List<String> commandList = new ArrayList<String>();
+        commandList.add("/bin/sh");
+        commandList.add("-c");
+        commandList.add(command);
+        return commandList.toArray(new String[commandList.size()]);
+    }
+
+    private static List<String> getImageURLs() {
+        List<String> imageURLs = new ArrayList<>();
+        File[] imageFiles = new File(DIR_IMAGES_PATH).listFiles();
+
+        for (File imageFile : imageFiles) {
+            if (imageFile.isFile()) {
+                String imageURL = IMAGE_URI + imageFile.getName();
+                log.debug("imageURL : {}", imageURL);
+                imageURLs.add(imageURL);
+            }
+        }
+        return imageURLs;
+    }
+
+    private ImageResourceUtils() {}
 }

--- a/BE/src/main/java/com/codesquad/team1/dust/util/ImageResourceUtils.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/util/ImageResourceUtils.java
@@ -4,22 +4,22 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class ImageResourceUtils {
 
     private static final Logger log = LoggerFactory.getLogger(ImageResourceUtils.class);
-    private static final String DIR_IMAGES_PATH = System.getProperty("user.dir") + "/src/main/resources/static/images";
-    private static final String IMAGE_URI = "http://ec2-15-164-254-158.ap-northeast-2.compute.amazonaws.com:8080/images/";
-    private static final String IMAGE_PREFIX = "forecast";
-    private static final int MAX_IMAGES = 48;
+    private static final String IMAGES_DIR_PATH = System.getProperty("user.dir") + "/src/main/resources/static/images";
+    private static final String IMAGES_URL_PATH = "http://ec2-15-164-254-158.ap-northeast-2.compute.amazonaws.com:8080/images/";
 
     public static List<String> parseImageURLs(JsonNode forecastObject) {
         log.debug("pm10 gif imageUrl7 : {}", forecastObject.get("imageUrl7"));
-        log.debug("resource path : {}", DIR_IMAGES_PATH);
-        excuteGIFSplit(String.format("convert %s %s/%s.png", forecastObject.get("imageUrl7"), DIR_IMAGES_PATH, IMAGE_PREFIX));
+        log.debug("resource path : {}", IMAGES_DIR_PATH);
+        excuteGIFSplit(String.format("convert %s %s/forecast-%%02d.png", forecastObject.get("imageUrl7"), IMAGES_DIR_PATH));
         return getImageURLs();
     }
 
@@ -55,9 +55,18 @@ public class ImageResourceUtils {
     }
 
     private static List<String> getImageURLs() {
+        File[] files = new File(IMAGES_DIR_PATH).listFiles();
+        return (files == null) ? new ArrayList<>() : getOrderedImageURLs(files);
+    }
+
+    private static List<String> getOrderedImageURLs(File[] files) {
         List<String> imageURLs = new ArrayList<>();
-        for (int i = 0; i < MAX_IMAGES; ++i)
-            imageURLs.add(String.format("%s%s-%d.png", IMAGE_URI, IMAGE_PREFIX, i));
+        for (File file : files) {
+            String fileName = file.getName();
+            if (fileName.contains(".png"))
+                imageURLs.add(IMAGES_URL_PATH + fileName);
+        }
+        Collections.sort(imageURLs);
         return imageURLs;
     }
 

--- a/BE/src/main/java/com/codesquad/team1/dust/util/PublicAPIUtils.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/util/PublicAPIUtils.java
@@ -24,7 +24,7 @@ public class PublicAPIUtils {
     public static JsonNode getForecastJSONObject(String searchDate) throws URISyntaxException, JsonProcessingException {
         log.debug("검색한 날짜: {}", searchDate);
         URI publicApiRequestUrl = new URI(PUBLIC_API_FORECAST_URL_AND_SEARCH_DATE + searchDate
-                + AND_SERVICE_KEY + PUBLIC_API_SERVICE_KEY + AND_RETURN_TYPE_JSON);
+                + AND_SERVICE_KEY + PUBLIC_API_SERVICE_KEY + AND_VERSION + 1.1 + AND_RETURN_TYPE_JSON);
         log.debug("requestUrl: {}", publicApiRequestUrl);
 
         String response = restTemplate.getForObject(publicApiRequestUrl, String.class);

--- a/BE/src/main/java/com/codesquad/team1/dust/util/ResourceUtils.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/util/ResourceUtils.java
@@ -3,7 +3,6 @@ package com.codesquad.team1.dust.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.IOException;

--- a/BE/src/main/java/com/codesquad/team1/dust/util/ResourceUtils.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/util/ResourceUtils.java
@@ -3,6 +3,7 @@ package com.codesquad.team1.dust.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,17 +11,24 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class ImageResourceUtils {
+public class ResourceUtils {
 
-    private static final Logger log = LoggerFactory.getLogger(ImageResourceUtils.class);
-    private static final String IMAGES_DIR_PATH = System.getProperty("user.dir") + "/src/main/resources/static/images";
-    private static final String IMAGES_URL_PATH = "http://ec2-15-164-254-158.ap-northeast-2.compute.amazonaws.com:8080/images/";
+    private static final Logger log = LoggerFactory.getLogger(ResourceUtils.class);
 
-    public static List<String> parseImageURLs(JsonNode forecastObject) {
-        log.debug("pm10 gif imageUrl7 : {}", forecastObject.get("imageUrl7"));
-        log.debug("resource path : {}", IMAGES_DIR_PATH);
-        excuteGIFSplit(String.format("convert %s %s/forecast-%%02d.png", forecastObject.get("imageUrl7"), IMAGES_DIR_PATH));
-        return getImageURLs();
+    public static final String PROJECT_IMAGES_DIR_PATH = System.getProperty("user.dir") + "/src/main/resources/static/images";
+    public static final String IMAGES_URL_PATH = "http://ec2-15-164-254-158.ap-northeast-2.compute.amazonaws.com:8080/images/";
+    public static final String COMMAND_CONVERT_GIF = "convert %s %s/forecast-%%02d.png";
+    public static final String FORECAST_API_GIF = "imageUrl7";
+
+    public static void convertGIFtoPNGs(JsonNode forecastObject) {
+        log.debug("pm10 gif imageUrl7 : {}", forecastObject.get(FORECAST_API_GIF));
+        log.debug("resource path : {}", PROJECT_IMAGES_DIR_PATH);
+        excuteGIFSplit(String.format(COMMAND_CONVERT_GIF, forecastObject.get(FORECAST_API_GIF), PROJECT_IMAGES_DIR_PATH));
+    }
+
+    public static List<String> getImageURLs() {
+        File[] files = new File(PROJECT_IMAGES_DIR_PATH).listFiles();
+        return (files == null) ? new ArrayList<>() : getOrderedImageURLs(files);
     }
 
     private static void excuteGIFSplit(String command) {
@@ -54,11 +62,6 @@ public class ImageResourceUtils {
         return commandList.toArray(new String[commandList.size()]);
     }
 
-    private static List<String> getImageURLs() {
-        File[] files = new File(IMAGES_DIR_PATH).listFiles();
-        return (files == null) ? new ArrayList<>() : getOrderedImageURLs(files);
-    }
-
     private static List<String> getOrderedImageURLs(File[] files) {
         List<String> imageURLs = new ArrayList<>();
         for (File file : files) {
@@ -70,5 +73,5 @@ public class ImageResourceUtils {
         return imageURLs;
     }
 
-    private ImageResourceUtils() {}
+    private ResourceUtils() {}
 }

--- a/BE/src/test/java/com/codesquad/team1/dust/domain/ForecastTest.java
+++ b/BE/src/test/java/com/codesquad/team1/dust/domain/ForecastTest.java
@@ -20,18 +20,21 @@ class ForecastTest {
 
     @Test
     void JsonNode로_Forecast객체_생성_테스트() throws JsonProcessingException {
+        final String fileName = "forecast-";
+        final int maxOfImages = 47;
         ObjectMapper mapper = new ObjectMapper();
         JsonNode forecastJsonNode = mapper.readTree("{\"_returnType\":\"json\",\"actionKnack\":\"\",\"dataTime\":\"2020-03-30 23시 발표\",\"f_data_time\":\"2020033023\",\"f_data_time1\":\"20200330\",\"f_data_time2\":\"20200331\",\"f_data_time3\":\"20200401\",\"f_inform_data\":\"20200330\",\"imageUrl1\":\"http://www.airkorea.or.kr/file/viewImage/?atch_id=138845\",\"imageUrl2\":\"http://www.airkorea.or.kr/file/viewImage/?atch_id=138846\",\"imageUrl3\":\"http://www.airkorea.or.kr/file/viewImage/?atch_id=138847\",\"imageUrl4\":\"http://www.airkorea.or.kr/file/viewImage/?atch_id=138848\",\"imageUrl5\":\"http://www.airkorea.or.kr/file/viewImage/?atch_id=138849\",\"imageUrl6\":\"http://www.airkorea.or.kr/file/viewImage/?atch_id=138850\",\"imageUrl7\":\"http://www.airkorea.or.kr/file/viewImage/?atch_id=138841\",\"imageUrl8\":\"http://www.airkorea.or.kr/file/viewImage/?atch_id=\",\"imageUrl9\":\"http://www.airkorea.or.kr/file/viewImage/?atch_id=\",\"informCause\":\"○ [미세먼지] 원활한 대기 확산으로 대기 상태가 대체로 '보통' 수준일 것으로 예상됨.\",\"informCode\":\"PM10\",\"informData\":\"2020-03-30\",\"informGrade\":\"서울 : 보통,제주 : 보통,전남 : 보통,전북 : 보통,광주 : 보통,경남 : 좋음,경북 : 좋음,울산 : 좋음,대구 : 좋음,부산 : 좋음,충남 : 보통,충북 : 보통,세종 : 보통,대전 : 보통,영동 : 좋음,영서 : 보통,경기남부 : 보통,경기북부 : 보통,인천 : 보통\",\"informOverall\":\"○ [미세먼지] 전 권역이 '좋음'∼'보통'으로 예상됨.\",\"numOfRows\":\"10\",\"pageNo\":\"1\",\"resultCode\":\"\",\"resultMsg\":\"\",\"searchDate\":\"\",\"serviceKey\":\"\",\"totalCount\":\"\",\"ver\":\"\"}");
 
         String informOverall = "○ [미세먼지] 전 권역이 '좋음'∼'보통'으로 예상됨.";
         String informGrade = "서울 : 보통,제주 : 보통,전남 : 보통,전북 : 보통,광주 : 보통,경남 : 좋음,경북 : 좋음,울산 : 좋음,대구 : 좋음,부산 : 좋음,충남 : 보통,충북 : 보통,세종 : 보통,대전 : 보통,영동 : 좋음,영서 : 보통,경기남부 : 보통,경기북부 : 보통,인천 : 보통";
         List<Image> images = new ArrayList<>();
-        images.add(new Image("http://www.airkorea.or.kr/file/viewImage/?atch_id=138845"));
-        images.add(new Image("http://www.airkorea.or.kr/file/viewImage/?atch_id=138846"));
-        images.add(new Image("http://www.airkorea.or.kr/file/viewImage/?atch_id=138847"));
+        for (int i = 0; i < maxOfImages; i++) {
+            String url = String.format("http://ec2-15-164-254-158.ap-northeast-2.compute.amazonaws.com:8080/images/%s%02d.png", fileName, i);
+            images.add(new Image(url));
+        }
 
         Forecast expected = new Forecast(informOverall, informGrade, images);
-        Forecast actual = new Forecast(forecastJsonNode);
+        Forecast actual = new Forecast(forecastJsonNode, images);
         assertThat(actual).isEqualToComparingFieldByField(expected);
         log.debug("JsonNode로 Forecast 객체를 생성하는데 성공하였습니다.");
     }


### PR DESCRIPTION
Closed #82
- 스프링 부트 구동 시, 예보 데이터를 요청하여 Gif를 여러 장의 png로 분리하도록 구현했습니다.
- 클라이언트에서 /forecast 요청 시에는 images 폴더에 존재하는 이미지 파일들에 대한 URL 리스트를 바로 반환하도록 구현했습니다.
- 공공 api 예보 데이터 요청 시, imageUrl7이 필요해서 버전을 파라미터로 추가적으로 전달했습니다.
- Forecast 생성자에서 이미지 url 주소 리스트를 전달하도록 수정했습니다. (Dion과 협의해야할 것 같습니다.)