### PR TITLE
[#95] Refactor: 위경도 전송하면 가장 가까운 관측소의 24시간 관측값 리스트 반환

### DIFF
--- a/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
+++ b/BE/src/main/java/com/codesquad/team1/dust/api/FineDustApiController.java
@@ -70,4 +70,17 @@ public class FineDustApiController {
         return forecast;
     }
 
+    @GetMapping("/daily-dust-status/@={latitude},{longitude}")
+    public List<DustStatus> showDailyDustStatusOfGPS(@PathVariable String latitude,
+                                                     @PathVariable String longitude) throws URISyntaxException, JsonProcessingException {
+        log.debug("위도: {}, 경도: {}", latitude, longitude);
+
+        StationLocation stationLocation = PublicAPIUtils.getNearestStationLocation(KakaoAPIUtils.getTmCoordinateSystem(latitude, longitude));
+        log.debug("stationLocation: {}", stationLocation);
+
+        List<DustStatus> dustStatusList = PublicAPIUtils.getDailyDustStatusJSONArray(stationLocation.getStationName());
+        log.debug("dustStatusList: {}", dustStatusList);
+
+        return dustStatusList;
+    }
 }


### PR DESCRIPTION
- /daily-dust-status/@={latitude},{longitude} 요청 시, 파라미터로 전송된 위경도와 가장 가까운 관측소를 찾고, 해당 관측소의 24시간 관측값 리스트를 반환하는 메소드 추가

- 기존에 만든 API Utils를 활용했습니다.